### PR TITLE
Added app from nuxt context to api_handler arguments

### DIFF
--- a/lib/plugins/api.template.js
+++ b/lib/plugins/api.template.js
@@ -39,7 +39,7 @@ function injectParamsIntoPath(path, params) {
  * @param controllerMapping
  * @return Object
  */
-function generateAPI(controllerMapping, ctx) {
+function generateAPI(controllerMapping, app) {
     const api = {};
     Object.keys(controllerMapping).forEach(function (key) {
         const context = controllerMapping[key];
@@ -55,20 +55,19 @@ function generateAPI(controllerMapping, ctx) {
                     context.verb,
                     values || {},
                     <%= options.apiConfig %>,
-                    ctx
+                    app
                 ).then(runResponseMiddleware);
             }
         } else if (typeof controllerMapping[key] === 'object') {
-            api[key] = generateAPI(controllerMapping[key], ctx);
+            api[key] = generateAPI(controllerMapping[key], app);
         }
     });
 
     return api;
 }
 
-export default (context) => {
-    const {app, req} = context;
-    const $api = process.server ? req._controllersTree : generateAPI(<%= options.controllers %>, context);
+export default ({app, req}) => {
+    const $api = process.server ? req._controllersTree : generateAPI(<%= options.controllers %>, app);
     app.$api = $api;
     Vue.prototype.$api = $api;
 };

--- a/lib/plugins/api.template.js
+++ b/lib/plugins/api.template.js
@@ -39,7 +39,7 @@ function injectParamsIntoPath(path, params) {
  * @param controllerMapping
  * @return Object
  */
-function generateAPI(controllerMapping) {
+function generateAPI(controllerMapping, ctx) {
     const api = {};
     Object.keys(controllerMapping).forEach(function (key) {
         const context = controllerMapping[key];
@@ -54,19 +54,21 @@ function generateAPI(controllerMapping) {
 					),
                     context.verb,
                     values || {},
-                    <%= options.apiConfig %>
+                    <%= options.apiConfig %>,
+                    ctx
                 ).then(runResponseMiddleware);
             }
         } else if (typeof controllerMapping[key] === 'object') {
-            api[key] = generateAPI(controllerMapping[key]);
+            api[key] = generateAPI(controllerMapping[key], ctx);
         }
     });
 
     return api;
 }
 
-export default ({app, req}) => {
-    const $api = process.server ? req._controllersTree : generateAPI(<%= options.controllers %>);
+export default (context) => {
+    const {app, req} = context;
+    const $api = process.server ? req._controllersTree : generateAPI(<%= options.controllers %>, context);
     app.$api = $api;
     Vue.prototype.$api = $api;
 };


### PR DESCRIPTION
This is useful because I can use context.$axios in accordance with nuxt-axios module instead of having to do an import of axios so that if anything is globally set to that instance I don't have to pass those onto the import of axios as well like with the case of authentication headers.