### PR TITLE
chore: add renovate to keep dependencies up-to-date

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,31 @@
+{
+  "extends": [
+    "config:base",
+    ":prHourlyLimit4",
+    ":semanticCommitTypeAll(chore)"
+  ],
+  "meteor": {
+    "enabled": false
+  },
+  "rangeStrategy": "bump",
+  "npm": {
+    "commitMessageTopic": "{{prettyDepType}} {{depName}}"
+  },
+  "packageRules": [
+    {
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch",
+      "matchFiles": ["package.json"],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "lockFileMaintenance": {
+        "enabled": true,
+        "extends": [
+          "schedule:weekly"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
I'm using similar config in https://github.com/nuxt-community/i18n-module/blob/main/renovate.json

BTW. I prefer renovate over dependabot since dependabot is very noisy with individual PRs for each dependency while renovate bundles them together.