### PR TITLE
chore(ci): only run linting in latest node to avoid double annotations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,7 @@ jobs:
       - name: yarn install
         run: yarn
       - name: Linting
+        if: ${{ matrix.node-version == '14.x' }}
         run: yarn lint
       - name: Unittesting
         run: yarn test


### PR DESCRIPTION
github annotates the code with linter issues and this has created
double of each linting warning.