### PR TITLE
fix: remove ctx from error after running error handler

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -60,7 +60,7 @@ export default async function NeoModule(moduleOptions) {
     this.addServerMiddleware(await injectAPI(moduleOptions));
 
     // Inject Route Controller mapping
-    this.addServerMiddleware(await injectRouteControllerMapping(moduleOptions));
+    this.addServerMiddleware(injectRouteControllerMapping(moduleOptions));
 
     // Inject client-side http global errors
     if (moduleOptions.httpErrors) {

--- a/lib/plugins/api.template.js
+++ b/lib/plugins/api.template.js
@@ -77,8 +77,9 @@ function generateAPI(controllerMapping, ctx) {
                     .then(runSuccessHandler)
                     .catch(err => {
                         err.ctx = ctx;
-
-                        return runErrorHandler(err);
+                        const result = runErrorHandler(err);
+                        delete err.ctx;
+                        return result;
                     });
             }
         } else if (typeof controllerMapping[key] === 'object') {

--- a/lib/utility/controllers.js
+++ b/lib/utility/controllers.js
@@ -233,7 +233,9 @@ export async function controllerMappingServerSide(directory, req, options, ctx) 
                 })
                 .catch(function (err) {
                     err.ctx = ctx;
-                    return ErrorHandler && ErrorHandler(err) || Promise.reject(err);
+                    const result = ErrorHandler && ErrorHandler(err) || Promise.reject(err);
+                    delete err.ctx;
+                    return result;
                 });
         };
     });


### PR DESCRIPTION
Remove monkey-patched `ctx` from the error object after running error handlers.

The reason for this is two-fold:
 - The added Context adds a lot of useless data to the error when logging the error to Sentry, for example
 - Sentry freezes permanently the app on the client side when trying to stringify the context object. This is more of a Sentry issue but still worth mentioning.