### PR TITLE
fix: ensure bundled version of path-to-regexp is used

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,7 +24,7 @@
         // Allow async-await
         "generator-star-spacing": "off",
         // Do not allow console.logs etc...
-        "no-console": 1,
+        "no-console": ["error", { "allow": ["warn", "error"] }],
         // Disallow multiple spaces unless in the EOL comments
         "no-multi-spaces": ["error", { "ignoreEOLComments": true }],
         // At most one empty line

--- a/lib/module.js
+++ b/lib/module.js
@@ -81,4 +81,6 @@ export default async function NeoModule(moduleOptions) {
             apiConfig: JSON.stringify(moduleOptions)
         }
     });
+
+    this.options.alias['~path-to-regexp'] = require.resolve('path-to-regexp');
 };

--- a/lib/plugins/api.template.js
+++ b/lib/plugins/api.template.js
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { compile as compilePath }  from 'path-to-regexp';
+import { compile as compilePath }  from '~path-to-regexp';
 import ApiHandler from '<%= options.apiHandlerFile %>';
 
 <% if (options.successHandlerFile) { %>
@@ -48,7 +48,12 @@ function generateAPI(controllerMapping, ctx) {
         if (context && context.path && context.verb) {
             const pathCompiler = compilePath(context.path, { encode: encodeURIComponent });
             api[key] = function ({params, ...values} = {}) {
-                const compiledPath = pathCompiler(params)
+                let compiledPath;
+                try {
+                    compiledPath = pathCompiler(params);
+                } catch (error) {
+                    throw new Error(`Error calling the nuxt-neo API (name: ${key}, path: ${context.path}): ${error.message}`);
+                }
                 return ApiHandler(
                     compiledPath,
                     context.verb,

--- a/lib/utility/controllers.js
+++ b/lib/utility/controllers.js
@@ -213,8 +213,11 @@ export async function controllerMappingServerSide(directory, req, options, ctx) 
         const controllerMiddleware = getControllerMiddleware(ControllerClass);
 
         return function ({ params, body, query } = {}) {
-            // Throws if params don't validate against the path.
-            pathCompiler(params);
+            try {
+                pathCompiler(params);
+            } catch (error) {
+                throw new Error(`Error calling the nuxt-neo API (name: ${actionName}, path: ${action.path}): ${error.message}`);
+            }
 
             return middlewareHandler(apiMiddleware, req)
                 .then(function () {

--- a/tests/api.flow.test.js
+++ b/tests/api.flow.test.js
@@ -69,7 +69,7 @@ test('Test hybrid api data flow client side', async (t) => {
     t.is(errorMessage.textContent, 'Forced error');
     t.falsy(errorMessageGetOptional);
     t.truthy(errorMessageGetWithoutParam);
-    t.is(errorMessageGetWithoutParam.textContent, 'Expected "id" to be a string');
+    t.true(errorMessageGetWithoutParam.textContent.includes('Error calling the nuxt-neo API'));
 
     changePath.dispatchEvent(new window.Event('click'));
     await new Promise(resolve => setTimeout(resolve, 2000)); // wait for API request
@@ -91,7 +91,7 @@ test('Test hybrid api data flow client side', async (t) => {
     changePathWithoutParam.dispatchEvent(new window.Event('click'));
     await new Promise(resolve => setTimeout(resolve, 2000)); // wait for API request
     errorMessage = window.document.querySelector('.index .error-message');
-    t.is(errorMessage.textContent, 'Expected "id" to be a string'); // error when no required param is given
+    t.true(errorMessage.textContent.includes('Error calling the nuxt-neo API')); // error when no required param is given
 
     getOptional.dispatchEvent(new window.Event('click'));
     await new Promise(resolve => setTimeout(resolve, 2000)); // wait for API request

--- a/tests/fixtures/layouts/error.vue
+++ b/tests/fixtures/layouts/error.vue
@@ -4,6 +4,11 @@
 
 <script>
 export default {
-    props: ['error']
+    props: {
+        error: {
+            type: Object,
+            default: null
+        }
+    }
 };
 </script>


### PR DESCRIPTION
We need to create an alias for `path-to-regexp` so that the client-side code resolves it to the version bundled with the module and not to whatever is hoisted to the root of `node_modules`. I'm using the same trick in `nuxt-i18n` for example, as suggested by Nuxt lead developers.

Also improved the error message on failing to parse path params to give more context to the error and help with finding the faulty route.