### PR TITLE
fix: reload controllers on change during development

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -49,9 +49,9 @@ const DEFAULT_MODULE_OPTIONS = {
 
 export default async function NeoModule(moduleOptions) {
     moduleOptions = Object.assign({}, DEFAULT_MODULE_OPTIONS, moduleOptions, this.options.nuxtNeo);
-    moduleOptions.aliasKey = /^[~|@]/g;
-    moduleOptions.srcDir = this.options.srcDir;
-    moduleOptions.directory = moduleOptions.directory.replace(moduleOptions.aliasKey, moduleOptions.srcDir);
+
+    moduleOptions.directory = this.nuxt.resolver.resolveAlias(moduleOptions.directory);
+    this.options.watch.push(moduleOptions.directory);
 
     // Globalize server-side http errors
     moduleOptions.httpErrors && await import('./utility/http_errors');
@@ -60,7 +60,7 @@ export default async function NeoModule(moduleOptions) {
     this.addServerMiddleware(await injectAPI(moduleOptions));
 
     // Inject Route Controller mapping
-    this.addServerMiddleware(injectRouteControllerMapping(moduleOptions));
+    this.addServerMiddleware(injectRouteControllerMapping(moduleOptions, this.nuxt.resolver));
 
     // Inject client-side http global errors
     if (moduleOptions.httpErrors) {

--- a/lib/server_middleware/api.js
+++ b/lib/server_middleware/api.js
@@ -185,12 +185,13 @@ export async function injectAPI(options) {
  * Injects Route Controller mapper.
  *
  * @param options
+ * @param resolver
  * @returns {Function}
  */
-export function injectRouteControllerMapping(options) {
+export function injectRouteControllerMapping(options, resolver) {
     return function (req, res, next) {
         req._controllersTree = async function (ctx) {
-            return await controllerMappingServerSide(options.directory, req, options, ctx);
+            return await controllerMappingServerSide(options.directory, req, options, resolver, ctx);
         };
 
         next();

--- a/lib/utility/controllers.js
+++ b/lib/utility/controllers.js
@@ -192,20 +192,16 @@ export async function controllerMappingClientSide(directory) {
  * @param directory
  * @param req
  * @param options
+ * @param resolver
  * @param ctx
  * @returns {Promise<Object>}
  */
-export async function controllerMappingServerSide(directory, req, options, ctx) {
+export async function controllerMappingServerSide(directory, req, options, resolver, ctx) {
     const apiMiddleware = options.middleware;
-    let SuccessHandler = options.successHandler
-        ? await import(options.successHandler.replace(options.aliasKey, options.srcDir))
-        : null;
-    let ErrorHandler = options.errorHandler
-        ? await import(options.errorHandler.replace(options.aliasKey, options.srcDir))
-        : null;
+    let SuccessHandler = options.successHandler ? await import(resolver.resolveAlias(options.successHandler)) : null;
+    let ErrorHandler = options.errorHandler ? await import(resolver.resolveAlias(options.errorHandler)) : null;
 
     SuccessHandler = SuccessHandler && SuccessHandler.default || SuccessHandler;
-
     ErrorHandler = ErrorHandler && ErrorHandler.default || ErrorHandler;
 
     return await controllerMapping(options.directory, function (ControllerClass, actionName, action) {

--- a/types/module.d.ts
+++ b/types/module.d.ts
@@ -92,10 +92,7 @@ declare module 'nuxt-neo' {
     }
 
     // Contains resolved values that are no longer optional and include some extra properties.
-    interface ResolvedModuleOptions extends Required<ModuleConfiguration> {
-        aliasKey: RegExp;
-        srcDir: string;
-    }
+    type ResolvedModuleOptions = Required<ModuleConfiguration>;
 
     // Types and interfaces for the controllers. The user can use those to annotate controllers.
 


### PR DESCRIPTION
Add a watcher so that whole Nuxt is reloaded on changing API routes and changes are applied at runtime.

Also switched to Nuxt's own `resolveAlias` helper instead of custom solution. This is not strictly related to the fix though.

Fixes #16