### PR TITLE
chore(ci): remove node 12 testing and add node 16

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       CI: true
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x]
     name: Use Node.js ${{ matrix.node-version }}
     steps:
       - uses: actions/checkout@v3
@@ -27,10 +27,10 @@ jobs:
       - name: yarn install
         run: yarn
       - name: Linting
-        if: ${{ matrix.node-version == '14.x' }}
+        if: ${{ matrix.node-version == '16.x' }}
         run: yarn lint
       - name: Unittesting
         run: yarn test
       - name: Coverage
-        if: ${{ matrix.node-version == '14.x' }}
+        if: ${{ matrix.node-version == '16.x' }}
         run: yarn coverage && yarn codecov -t ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Some dev dependencies no longer support Node 12 but in any case I think it's time to officially drop support for Node 12.