### PR TITLE
fix: support .ts files for controllers

### DIFF
--- a/lib/server_middleware/api.js
+++ b/lib/server_middleware/api.js
@@ -104,7 +104,7 @@ function injectBodyParsers(options) {
 async function injectControllers(router, options) {
     for (const path of getControllerFiles(options.directory)) {
         const relativePath = path.replace(options.directory, '');
-        const routePrefix = relativePath.replace(/\/index|\.js/g, '').split('/').map(camelcaseToDashcase).join('/');
+        const routePrefix = relativePath.replace(/\/index|\.(js|ts)/g, '').split('/').map(camelcaseToDashcase).join('/');
 
         router.use(routePrefix, await createControllerRouter(path, options));
     };

--- a/lib/utility/controllers.js
+++ b/lib/utility/controllers.js
@@ -138,7 +138,7 @@ async function controllerMappingRecursive(mapping, parts, onEmpty) {
 async function controllerMapping(directory, controllerValue) {
     const mapping = {};
     for (const path of getControllerFiles(directory)) {
-        const relativePath = path.replace(directory, '').replace(/\/index|\.js/g, '');
+        const relativePath = path.replace(directory, '').replace(/\/index|\.(js|ts)/g, '');
         const routePrefix = relativePath.split('/').map(camelcaseToDashcase).join('/');
 
         await controllerMappingRecursive(mapping, relativePath.substring(1).split('/'), async function () {


### PR DESCRIPTION
Fixes #109

Adds support for Typescript `.ts` files when generating routes.